### PR TITLE
add ip2location support to goworker

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ There are currently few tools that measure how engaged a user is when viewing on
   export GOPATH=/path_to_go
   go get github.com/benmanns/goworker
   go get github.com/xlvector/hector
-  go get github.com/xlvector/hector/hectorcv
-
+  go get github.com/ip2location/ip2location-go
 ```
 
 don't use rails server for local development, use:
@@ -91,6 +90,12 @@ react is a dependency so get [react developer tools for chrome](https://chrome.g
   add `byebug` to line in code
   bundle exec byebug -R localhost:1048
   hit api endpoint with `byebug` line
+```
+
+For debugging goworkers, use delve
+
+```unix
+  brew install delve
 ```
 
 ##### Deploying

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -21,8 +21,10 @@ module Api::V1
     end
 
     def value_params
-      data_params.permit(:referrer, :x_pos, :y_pos, :is_visible,
-                         :in_viewport, :top, :bottom, :word_count)
+      data_params.
+        permit(:referrer, :x_pos, :y_pos, :is_visible,
+               :in_viewport, :top, :bottom, :word_count).
+        merge(remote_ip: request.remote_ip, user_agent: request.user_agent)
     end
   end
 end


### PR DESCRIPTION
Updates:

- add ip2location support. Event Score measurements now will locate region country & city based on a specified remote IP address
- minor updates to readme
- Event Score measurements now include user agent 