### PR TITLE
PDF Report Feature and Transactional Emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'jquery-rails'
 gem 'mini_magick'
 gem 'oj'
 gem 'oj_mimic_json'
+gem 'pdfkit'
 gem 'powder'
 gem 'puma'
 gem 'rails', '4.2.7.1'
@@ -31,8 +32,10 @@ gem 'pundit'
 gem 'sidekiq'
 gem 'sinatra', :require => false
 gem 'whenever', :require => false
+gem 'wkhtmltopdf-binary'
 group :development do
   gem 'better_errors'
+  gem 'letter_opener'
   gem 'quiet_assets'
   gem 'rails_layout'
   gem 'spring'

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'devise'
 gem 'foreman'
 gem 'foundation-rails', '6.2.3.0'
 gem 'pg'
+gem 'premailer-rails'
 gem 'pundit'
 gem 'sidekiq'
 gem 'sinatra', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
+    css_parser (1.4.6)
+      addressable
     data_migrate (2.1.0)
       rails (>= 4.0)
     database_cleaner (1.5.3)
@@ -144,6 +146,7 @@ GEM
       activesupport (>= 4.1.0)
     hashie (3.4.4)
     high_voltage (3.0.0)
+    htmlentities (4.3.4)
     i18n (0.7.0)
     influxdb (0.2.6)
       json
@@ -191,6 +194,12 @@ GEM
     pg (0.18.4)
     powder (0.3.0)
       thor (>= 0.11.5)
+    premailer (1.8.7)
+      css_parser (>= 1.4.5)
+      htmlentities (>= 4.0.0)
+    premailer-rails (1.9.4)
+      actionmailer (>= 3, < 6)
+      premailer (~> 1.7, >= 1.7.9)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -366,6 +375,7 @@ DEPENDENCIES
   pdfkit
   pg
   powder
+  premailer-rails
   pry-rails
   pry-rescue
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,8 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -185,6 +187,7 @@ GEM
     oj (2.16.1)
     oj_mimic_json (1.0.1)
     orm_adapter (0.5.0)
+    pdfkit (0.8.2)
     pg (0.18.4)
     powder (0.3.0)
       thor (>= 0.11.5)
@@ -324,6 +327,7 @@ GEM
     websocket (1.2.3)
     whenever (0.9.7)
       chronic (>= 0.6.3)
+    wkhtmltopdf-binary (0.12.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -355,9 +359,11 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   launchy
+  letter_opener
   mini_magick
   oj
   oj_mimic_json
+  pdfkit
   pg
   powder
   pry-rails
@@ -381,6 +387,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   whenever
+  wkhtmltopdf-binary
 
 RUBY VERSION
    ruby 2.2.3p173

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -67,7 +67,7 @@ $foundation-palette: (
   secondary: #777,
   success: #3adb76,
   warning: #ffae00,
-  alert: #ec5840,
+  alert: rgba(0, 0, 0, 0),
 );
 $light-gray: #e6e6e6;
 $medium-gray: #cacaca;

--- a/app/assets/stylesheets/email.css
+++ b/app/assets/stylesheets/email.css
@@ -1,0 +1,279 @@
+/*https://github.com/mailgun/transactional-email-templates*/
+
+* {
+  margin: 0;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+img {
+  max-width: 100%;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  -webkit-text-size-adjust: none;
+  width: 100% !important;
+  height: 100%;
+  line-height: 1.6em;
+  /* 1.6em * 14px = 22.4px, use px to get airier line-height also in Thunderbird, and Yahoo!, Outlook.com, AOL webmail clients */
+  /*line-height: 22px;*/
+}
+
+/* Let's make sure all tables have defaults */
+table td {
+  vertical-align: top;
+}
+
+/* -------------------------------------
+    BODY & CONTAINER
+------------------------------------- */
+body {
+  background-color: #f6f6f6;
+}
+
+.body-wrap {
+  background-color: #f6f6f6;
+  width: 100%;
+}
+
+.container {
+  display: block !important;
+  max-width: 600px !important;
+  margin: 0 auto !important;
+  /* makes it centered */
+  clear: both !important;
+}
+
+.content {
+  max-width: 600px;
+  margin: 0 auto;
+  display: block;
+  padding: 20px;
+}
+
+/* -------------------------------------
+    HEADER, FOOTER, MAIN
+------------------------------------- */
+.main {
+  background-color: #67608b;
+  color: white;
+  border: 1px solid #e9e9e9;
+  border-radius: 3px;
+}
+
+.content-wrap {
+  padding: 20px;
+}
+
+.content-block {
+  padding: 0 0 20px;
+}
+
+.header {
+  width: 100%;
+  margin-bottom: 20px;
+}
+
+.footer {
+  width: 100%;
+  clear: both;
+  color: #999;
+  padding: 20px;
+}
+.footer p, .footer a, .footer td {
+  color: #999;
+  font-size: 12px;
+}
+
+/* -------------------------------------
+    TYPOGRAPHY
+------------------------------------- */
+h1, h2, h3 {
+  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  color: #000;
+  margin: 40px 0 0;
+  line-height: 1.2em;
+  font-weight: 400;
+}
+
+h1 {
+  font-size: 32px;
+  font-weight: 500;
+  /* 1.2em * 32px = 38.4px, use px to get airier line-height also in Thunderbird, and Yahoo!, Outlook.com, AOL webmail clients */
+  /*line-height: 38px;*/
+}
+
+h2 {
+  font-size: 24px;
+  /* 1.2em * 24px = 28.8px, use px to get airier line-height also in Thunderbird, and Yahoo!, Outlook.com, AOL webmail clients */
+  /*line-height: 29px;*/
+}
+
+h3 {
+  font-size: 18px;
+  /* 1.2em * 18px = 21.6px, use px to get airier line-height also in Thunderbird, and Yahoo!, Outlook.com, AOL webmail clients */
+  /*line-height: 22px;*/
+}
+
+h4 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+p, ul, ol {
+  margin-bottom: 10px;
+  font-weight: normal;
+}
+p li, ul li, ol li {
+  margin-left: 5px;
+  list-style-position: inside;
+}
+
+/* -------------------------------------
+    LINKS & BUTTONS
+------------------------------------- */
+a {
+  color: #348eda;
+  text-decoration: underline;
+}
+
+.btn-primary {
+  text-decoration: none;
+  color: #FFF;
+  background-color: #348eda;
+  border: solid #348eda;
+  border-width: 10px 20px;
+  line-height: 2em;
+  /* 2em * 14px = 28px, use px to get airier line-height also in Thunderbird, and Yahoo!, Outlook.com, AOL webmail clients */
+  /*line-height: 28px;*/
+  font-weight: bold;
+  text-align: center;
+  cursor: pointer;
+  display: inline-block;
+  border-radius: 5px;
+  text-transform: capitalize;
+}
+
+/* -------------------------------------
+    OTHER STYLES THAT MIGHT BE USEFUL
+------------------------------------- */
+.last {
+  margin-bottom: 0;
+}
+
+.first {
+  margin-top: 0;
+}
+
+.aligncenter {
+  text-align: center;
+}
+
+.alignright {
+  text-align: right;
+}
+
+.alignleft {
+  text-align: left;
+}
+
+.clear {
+  clear: both;
+}
+
+/* -------------------------------------
+    ALERTS
+    Change the class depending on warning email, good email or bad email
+------------------------------------- */
+.alert {
+  font-size: 16px;
+  color: #fff;
+  font-weight: 500;
+  padding: 20px;
+  text-align: center;
+  border-radius: 3px 3px 0 0;
+}
+.alert a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 16px;
+}
+.alert.alert-warning {
+  background-color: #FF9F00;
+}
+.alert.alert-bad {
+  background-color: #D0021B;
+}
+.alert.alert-good {
+  background-color: #68B90F;
+}
+
+/* -------------------------------------
+    INVOICE
+    Styles for the billing table
+------------------------------------- */
+.invoice {
+  margin: 40px auto;
+  text-align: left;
+  width: 80%;
+}
+.invoice td {
+  padding: 5px 0;
+}
+.invoice .invoice-items {
+  width: 100%;
+}
+.invoice .invoice-items td {
+  border-top: #eee 1px solid;
+}
+.invoice .invoice-items .total td {
+  border-top: 2px solid #333;
+  border-bottom: 2px solid #333;
+  font-weight: 700;
+}
+
+/* -------------------------------------
+    RESPONSIVE AND MOBILE FRIENDLY STYLES
+------------------------------------- */
+@media only screen and (max-width: 640px) {
+  body {
+    padding: 0 !important;
+  }
+
+  h1, h2, h3, h4 {
+    font-weight: 800 !important;
+    margin: 20px 0 5px !important;
+  }
+
+  h1 {
+    font-size: 22px !important;
+  }
+
+  h2 {
+    font-size: 18px !important;
+  }
+
+  h3 {
+    font-size: 16px !important;
+  }
+
+  .container {
+    padding: 0 !important;
+    width: 100% !important;
+  }
+
+  .content {
+    padding: 0 !important;
+  }
+
+  .content-wrap {
+    padding: 10px !important;
+  }
+
+  .invoice {
+    width: 100% !important;
+  }
+}

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -15,7 +15,7 @@ body.pages {
   }
 }
 
-body.pages, body.sessions, body.registrations {
+body.pages, body.sessions, body.registrations, body.passwords {
   background: $dark-purple;
 }
 
@@ -26,7 +26,9 @@ h1 {
 }
 
 .authform {
-  background-color: #FFF;
+  background-color: $ultra-light-purple;
+  border-top: 2px solid darken($dark-purple, 20%);
+  margin-top: 2rem;
   padding: 2rem;
   box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
 }

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -1,0 +1,76 @@
+html {
+  box-sizing: border-box;
+  overflow-y: scroll; /* All browsers without overlaying scrollbars */
+  -webkit-text-size-adjust: 100%; /* iOS 8+ */
+  height: 100%;
+}
+
+body {
+  height: 100%;
+}
+
+*,
+::before,
+::after {
+  box-sizing: inherit;
+}
+
+::before,
+::after {
+  text-decoration: inherit; /* Inherit text-decoration and vertical align to ::before and ::after pseudo elements */
+  vertical-align: inherit;
+}
+
+/* Remove margin, padding of all elements and set background-no-repeat as default */
+* {
+  background-repeat: no-repeat; /* Set `background-repeat: no-repeat` to all elements */
+  padding: 0; /* Reset `padding` and `margin` of all elements */
+  margin: 0;
+}
+
+header {
+  padding: 15px;
+  height: 80px;
+}
+
+section {
+  padding: 15px;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  empty-cells: show;
+  border: 1px solid #cbcbcb;
+}
+
+table td,
+table th {
+  border-top: 1px solid #cbcbcb;
+  border-left: 1px solid #cbcbcb;
+  border-width: 1px 0 0 1px;
+  font-size: inherit;
+  margin: 0;
+  overflow: visible;
+  padding: 0.5em 1em;
+}
+
+table td:first-child,
+table th:first-child {
+  border-left-width: 0;
+}
+
+table thead {
+  background-color: #e0e0e0;
+  color: #000;
+  text-align: left;
+  vertical-align: bottom;
+}
+
+table td {
+  background-color: transparent;
+}
+
+table td.odd {
+  background-color: #f2f2f2;
+}

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -14,6 +14,7 @@ module Api::V1
       render({json: {uuid: api_key.uuid, name: api_key.name}})
     end
 
+    protected
     def get_user
       @user = User.find(params.require(:user_id))
     end

--- a/app/controllers/api/v1/metrics_controller.rb
+++ b/app/controllers/api/v1/metrics_controller.rb
@@ -1,5 +1,5 @@
 module Api::V1
-  class ReportsController < ApiController
+  class MetricsController < ApiController
     def create
       data = {
         tags: tag_params,

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,7 +7,7 @@ module Api::V1
     end
 
     def user_params
-      params.require(:user).permit(:name, :avatar)
+      params.require(:user).permit(:name, :avatar, :permissions)
     end
   end
 end

--- a/app/controllers/concerns/reportable.rb
+++ b/app/controllers/concerns/reportable.rb
@@ -1,0 +1,8 @@
+module Reportable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :report_summaries, class_name: "Report::Summary"
+    has_many :report_summary_users, through: :report_summaries, source: :user
+  end
+end

--- a/app/controllers/dashboard/reports_controller.rb
+++ b/app/controllers/dashboard/reports_controller.rb
@@ -1,7 +1,17 @@
 module Dashboard
   class ReportsController < ApplicationController
     def index
-      @api_keys = current_user.api_keys
+      @report_summaries = current_user.report_summaries.includes(:api_key)
+      @api_keys = current_user.api_keys.where.not(id: @report_summaries.pluck(:api_key_id))
+    end
+
+    def create
+      @report_summary = current_user.report_summaries.create(report_summary_params)
+      render @report_summary
+    end
+
+    def report_summary_params
+      params.require(:report_summary).permit(:api_key_id, :frequency)
     end
   end
 end

--- a/app/jobs/reports/summary_job.rb
+++ b/app/jobs/reports/summary_job.rb
@@ -13,7 +13,7 @@ class Reports::SummaryJob < ActiveJob::Base
           top_scores_by_source_url: Event::Score.top_scores_by_source_url(api_key.uuid)
         }
         emails = api_key.report_summary_users.map(&:email)
-        Report::SummaryMailer.notify(emails, data).deliver_later
+        Reports::SummaryMailer.notify(emails, data, api_key.name).deliver_now
       end
   end
 end

--- a/app/jobs/reports/summary_job.rb
+++ b/app/jobs/reports/summary_job.rb
@@ -1,0 +1,19 @@
+class Reports::SummaryJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(frequency)
+    ApiKey.
+      joins(:report_summary_users).
+      merge(Report::Summary.send(frequency)).
+      merge(User.allow_all).
+      find_each do |api_key|
+        data = {
+          last_10_visits: Event::Score.find_by_api_key(api_key.uuid),
+          top_visits_by_source: Event::Score.top_visits_by_source_url(api_key.uuid),
+          top_scores_by_source_url: Event::Score.top_scores_by_source_url(api_key.uuid)
+        }
+        emails = api_key.report_summary_users.map(&:email)
+        Report::SummaryMailer.notify(emails, data).deliver_later
+      end
+  end
+end

--- a/app/mailers/reports/summary_mailer.rb
+++ b/app/mailers/reports/summary_mailer.rb
@@ -1,0 +1,10 @@
+class Reports::SummaryMailer < ActionMailer::Base
+  def notify(emails, data)
+    kit = PDFKit.new(render_to_string("pdf/report_summary", layout: "print", locals: data))
+    kit.stylesheets << File.join(Rails.root + "app/assets/stylesheets/print.css")
+    attachments["report_summary.pdf"] = kit.to_pdf
+    mail(to: "no-reply@example.com",
+         from: "no-reply@example.com",
+         bcc: emails)
+  end
+end

--- a/app/mailers/reports/summary_mailer.rb
+++ b/app/mailers/reports/summary_mailer.rb
@@ -1,10 +1,15 @@
 class Reports::SummaryMailer < ActionMailer::Base
-  def notify(emails, data)
+  layout "email"
+
+  def notify(emails, data, name)
+    attachments.inline["logo.png"] = File.read("#{Rails.root.to_s + '/app/assets/images/engage-logo-multicolor-masked-dark.png'}")
+    @name = name
     kit = PDFKit.new(render_to_string("pdf/report_summary", layout: "print", locals: data))
     kit.stylesheets << File.join(Rails.root + "app/assets/stylesheets/print.css")
     attachments["report_summary.pdf"] = kit.to_pdf
     mail(to: "no-reply@example.com",
          from: "no-reply@example.com",
+         subject: "Report Summary for #{name}",
          bcc: emails)
   end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,4 +1,6 @@
 class ApiKey < ActiveRecord::Base
+  include Reportable
+
   acts_as_paranoid column: :expired_at
 
   has_one :client_api_key

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,5 @@
+module Report
+  def self.table_name_prefix
+    'report_'
+  end
+end

--- a/app/models/report/summary.rb
+++ b/app/models/report/summary.rb
@@ -1,0 +1,7 @@
+module Report
+  class Summary < ActiveRecord::Base
+    belongs_to :user
+    belongs_to :api_key
+    enum frequency: [:daily, :weekly]
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,11 @@ class User < ActiveRecord::Base
   belongs_to :client
   has_many :client_api_keys, foreign_key: :client_id, primary_key: :client_id
   has_many :api_keys, through: :client_api_keys
+  has_many :report_summaries, class_name: "Report::Summary"
 
   enum role: [:user, :vip, :admin]
-  after_initialize :set_default_role, :if => :new_record?
+  enum permissions: [:allow_all, :no_emails]
+  after_initialize :set_default_role, if: :new_record?
 
   mount_uploader :avatar, AvatarUploader
 

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |name, msg| %>
   <div class="alert callout" data-closable>
-    <p><%= msg %></p>
+    <h6><%= msg %></h6>
     <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
       <span aria-hidden="true">&times;</span>
     </button>

--- a/app/views/application/_sub_nav.html.erb
+++ b/app/views/application/_sub_nav.html.erb
@@ -1,5 +1,5 @@
-<div class="top-bar sub_nav" style="text-align:center">
-  <div style="position:absolute" class="top-bar-left">
+<div class="top-bar sub_nav text-center">
+  <div class="top-bar-left">
     <span class="menu-text">
       <i class="icon-search"></i>
     </span>

--- a/app/views/dashboard/details/show.html.erb
+++ b/app/views/dashboard/details/show.html.erb
@@ -2,8 +2,8 @@
   <div class="large-12 columns">
     <nav aria-label="You are here:" role="navigation">
       <ul class="breadcrumbs">
-        <li><%= link_to "Home", root_path %></li>
-        <li><%= link_to "Events", dashboard_event_path(@api_key.uuid) %></li>
+        <li><%= link_to "Events", dashboard_events_path %></li>
+        <li><%= link_to @api_key.name, dashboard_event_path(@api_key.uuid) %></li>
         <li style="color: #7F8AA2">
           <span class="show-for-sr">Current</span><%= @result.values.first.source_url %>
         </li>

--- a/app/views/dashboard/events/index.html.erb
+++ b/app/views/dashboard/events/index.html.erb
@@ -3,7 +3,7 @@
     <nav aria-label="You are here:" role="navigation">
       <ul class="breadcrumbs">
         <li>
-          <span class="show-for-sr">Current: </span> Home
+          <span class="show-for-sr">Current: </span> Events
         </li>
       </ul>
     </nav>

--- a/app/views/dashboard/events/show.html.erb
+++ b/app/views/dashboard/events/show.html.erb
@@ -2,9 +2,9 @@
   <div class="large-6 columns">
     <nav aria-label="You are here:" role="navigation">
       <ul class="breadcrumbs">
-        <li><%= link_to "Home", root_path %></li>
+        <li><%= link_to "Events", dashboard_events_path %></li>
         <li>
-          <span class="show-for-sr">Current: </span> Events
+          <span class="show-for-sr">Current: </span> <%= @api_key.name %>
         </li>
       </ul>
     </nav>

--- a/app/views/dashboard/main/index.html.erb
+++ b/app/views/dashboard/main/index.html.erb
@@ -3,7 +3,6 @@
     <div class="row">
       <h4>Choose from the options on the right to get started</h4>
       <h6>ipsum Lorem ipsum dolor sit amet, consectetur adipisicing elit</h6>
-      <div style="text-align: center"><i style="font-size:10rem" class="icon-line-graph"></i></div>
     </div>
   </div>
   <div class="large-5 columns">

--- a/app/views/dashboard/reports/index.html.erb
+++ b/app/views/dashboard/reports/index.html.erb
@@ -1,0 +1,65 @@
+<div class="row" style="margin-top: 2rem">
+  <div class="large-6 columns">
+    <nav aria-label="You are here:" role="navigation">
+      <ul class="breadcrumbs">
+        <li>
+          <span class="show-for-sr">Current: </span> Reports
+        </li>
+      </ul>
+    </nav>
+  </div>
+  <div class="large-6 columns">
+    <div class="callout">
+    </div>
+  </div>
+</div>
+<% if @api_keys.present? %>
+  <div class="row">
+    <div class="large-12 columns">
+      <h6 class="category">Add New Report</h6>
+    </div>
+  </div>
+  <div class="row">
+    <div class="large-12 columns">
+      <div class="callout">
+      <%= form_for(current_user.report_summaries.new, url: dashboard_reports_path) do |f| %>
+        <%= f.label "API Key" %>
+        <%= f.collection_select :api_key_id, @api_keys, :id, :name, prompt: true %>
+        <%= f.label "Frequency" %>
+        <%= f.select(:frequency, options_for_select([["Daily", "daily"], ["Weekly", "weekly"]])) %>
+        </label>
+        <%= f.submit "Create", class: "button" %>
+      <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>
+<div class="row">
+  <div class="large-12 columns">
+    <h6 class="category">Reports</h6>
+  </div>
+</div>
+<div class="row">
+  <div class="large-12 columns">
+    <div class="callout">
+      <table>
+        <thead>
+          <tr>
+            <th>API Key</th>
+            <th>Frequency</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @report_summaries.each do |report| %>
+            <tr>
+              <td><%= "#{report.api_key.name} (#{(report.api_key.uuid)})" %></td>
+              <td><%= report.frequency %></td>
+              <td><%= report.created_at.to_s(:date_and_time) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboard/settings/index.html.erb
+++ b/app/views/dashboard/settings/index.html.erb
@@ -26,6 +26,13 @@
         <div class="form-group">
           <%= f.label :first_name, "First name" %>
           <%= f.text_field :name, class: "form-control inline-editable" %>
+          <%= f.label :permissions, "Permissions" %>
+          <fieldset>
+            <%= f.radio_button :permissions, "allow_all", class: "inline-editable", checked: (current_user.permissions == "allow_all") %>
+            <%= f.label :permissions, "Allow All", value: "allow_all" %>
+            <%= f.radio_button :permissions, "no_emails", class: "inline-editable", checked: (current_user.permissions == "no_emails") %>
+            <%= f.label :permissions, "No Emails", value: "no_emails" %>
+          </fieldset>
           <%= f.label :avatar_label, "Profile Avatar" %>
           <%= f.label :avatar, current_user.avatar.present? ? current_user.avatar.file.identifier : "No Avatar", class: "button" %>
           <%= f.file_field :avatar, class: "show-for-sr inline-editable" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,12 +1,16 @@
-<div class="authform">
-  <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post, :role => 'form'}) do |f| %>
-    <h3>Forgot your password?</h3>
-    <p>We'll send password reset instructions.</p>
-    <%= devise_error_messages! %>
-    <div class="form-group">
-      <%= f.label :email %>
-      <%= f.email_field :email, :autofocus => true, class: 'form-control' %>
+<div class="small-10 medium-6 large-4 small-centered">
+  <div class="row">
+    <div class="authform">
+      <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post, :role => 'form'}) do |f| %>
+        <h4>Forgot your password?</h4>
+        <h6>We'll send password reset instructions.</h6>
+        <%= devise_error_messages! %>
+        <div class="form-group">
+          <%= f.label :email %>
+          <%= f.email_field :email, :autofocus => true, class: 'form-control' %>
+        </div>
+         <%= f.submit 'Reset Password', :class => 'button right' %>
+      <% end %>
     </div>
-     <%= f.submit 'Reset Password', :class => 'button right' %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,8 +1,8 @@
-<div class="small-6 small-centered">
-  <div class="row" style="margin-top: 2rem">
+<div class="small-10 medium-6 large-4 small-centered">
+  <div class="row">
     <div class="authform">
       <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :role => 'form'}) do |f| %>
-        <h3>Sign up</h3>
+        <h4>Sign up</h4>
         <%= devise_error_messages! %>
         <div class="form-group">
           <%= f.label :name %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,8 @@
-<div class="small-6 small-centered">
-  <div class="row" style="margin-top: 2rem">
+<div class="small-10 medium-6 large-4 small-centered">
+  <div class="row">
     <div class="authform">
       <%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :role => 'form'}) do |f| %>
-        <h3>Sign in</h3>
+        <h4>Sign in</h4>
         <%= devise_error_messages! %>
         <div class="form-group">
           <%= f.label :email %>
@@ -14,10 +14,11 @@
         </div>
           <%= f.submit 'Sign in', :class => 'button right' %>
           <% if devise_mapping.rememberable? -%>
-            <div class="checkbox" style="width:150px">
-              <label>
+            <div class="checkbox clearfix">
+              <label class="float-left">
                 <%= f.check_box :remember_me %> Remember me
               </label>
+              <label class="float-right"><%= link_to "Forgot Your Password?", new_password_path('user'), class: "login-link" %></label>
             </div>
           <% end -%>
       <% end %>

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -1,0 +1,43 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Engage Email</title>
+    <%= stylesheet_link_tag "email" %>
+  </head>
+  <body>
+    <table class="body-wrap">
+      <tr>
+        <td></td>
+        <td class="container" width="600">
+          <div class="content">
+            <table class="main" width="100%" cellpadding="0" cellspacing="0">
+              <tr>
+                <td class="content-wrap">
+                  <table width="100%" cellpadding="0" cellspacing="0">
+                    <tr class="content-wrap">
+                      <td class="aligncenter content-wrap">
+                        <%= image_tag attachments["logo.png"].url, size: "172x63" %>
+                      </td>
+                    </tr>
+                    <%= yield %>
+                  </table>
+                </td>
+              </tr>
+            </table>
+            <div class="footer">
+              <table width="100%">
+                <tr>
+                  <td class="aligncenter content-block">
+                    Brought to you by <a href="#">Engage</a>
+                  </td>
+                </tr>
+              </table>
+            </div></div>
+        </td>
+        <td></td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/layouts/print.html.erb
+++ b/app/views/layouts/print.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Report Summary</title>
+    <%= stylesheet_link_tag "print" %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/pdf/report_summary.html.erb
+++ b/app/views/pdf/report_summary.html.erb
@@ -1,0 +1,30 @@
+<header>
+  <h1>Engage</h1>
+  <span>Summary Report for <%= Date.current.to_s(:date_only) %></span>
+</header>
+<% local_assigns.keys.each do |key| %>
+  <% kv_pairs = local_assigns[key].values.first.to_h.keys %>
+  <section>
+    <table>
+      <thead>
+        <tr>
+          <th colspan="<%= kv_pairs.size %>"><%= key.to_s.titleize %></th>
+        </tr>
+        <tr>
+          <% kv_pairs.each do |value| %>
+            <th><%= value.to_s.humanize %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% local_assigns[key].values.each do |value| %>
+          <tr>
+            <% value.to_h.values.each do |key| %>
+              <td><%= key %></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </section>
+<% end %>

--- a/app/views/reports/summary_mailer/notify.html.erb
+++ b/app/views/reports/summary_mailer/notify.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <td class="content-block">
+    Report Summary for: <%= @name %>
+  </td>
+</tr>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.asset_host      = "localhost"
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,7 +14,7 @@ Rails.application.config.assets.version = '1.0'
 # If you do not want to move existing images and fonts from your Rails app
 # you could also consider creating symlinks there that point to the original
 # rails directories. In that case, you would not add these paths here.
-Rails.application.config.assets.precompile += %w( server-bundle.js entypo.css print.css )
+Rails.application.config.assets.precompile += %w( server-bundle.js entypo.css print.css email.css )
 
 # Add folder with webpack generated assets to assets.paths
 Rails.application.config.assets.paths << Rails.root.join("app", "assets", "webpack")

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,7 +14,7 @@ Rails.application.config.assets.version = '1.0'
 # If you do not want to move existing images and fonts from your Rails app
 # you could also consider creating symlinks there that point to the original
 # rails directories. In that case, you would not add these paths here.
-Rails.application.config.assets.precompile += %w( server-bundle.js entypo.css )
+Rails.application.config.assets.precompile += %w( server-bundle.js entypo.css print.css )
 
 # Add folder with webpack generated assets to assets.paths
 Rails.application.config.assets.paths << Rails.root.join("app", "assets", "webpack")

--- a/config/initializers/pdfkit.rb
+++ b/config/initializers/pdfkit.rb
@@ -1,0 +1,7 @@
+PDFKit.configure do |config|
+  config.default_options = {
+    :page_size => 'Legal',
+    :print_media_type => true
+  }
+  config.verbose = true
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -44,7 +44,7 @@ en:
       updated: "Your account has been updated successfully."
     sessions:
       signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
+      signed_out: ""
       already_signed_out: "Signed out successfully."
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   # constraints subdomain: "api" do
     scope module: "api", path: nil, defaults: {format: :json} do
       namespace :v1 do
-        resources :reports, only: :create
+        resources :metrics, only: :create
         resources :api_keys, only: [:create, :destroy], param: :uuid
         resources :users, only: :update
       end
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
         resources :details, only: [:show, :index]
       end
       resources :settings, only: [:index]
-      resources :reports, only: [:index]
+      resources :reports, only: [:index, :create]
       resources :notifications, only: [:index]
       resources :insights, only: [:index]
       resource :main, only: :index

--- a/db/migrate/20161023231518_add_permissions_to_users.rb
+++ b/db/migrate/20161023231518_add_permissions_to_users.rb
@@ -1,0 +1,5 @@
+class AddPermissionsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :permissions, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20161024141207_create_report_summaries.rb
+++ b/db/migrate/20161024141207_create_report_summaries.rb
@@ -1,0 +1,10 @@
+class CreateReportSummaries < ActiveRecord::Migration
+  def change
+    create_table :report_summaries do |t|
+      t.references :user, index: true, foreign_key: true, null: false
+      t.references :api_key, index: true, foreign_key: true, null: false
+      t.integer :frequency, default: 0, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161020130240) do
+ActiveRecord::Schema.define(version: 20161024141207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,17 @@ ActiveRecord::Schema.define(version: 20161020130240) do
 
   add_index "data_migrations", ["version"], name: "unique_data_migrations", unique: true, using: :btree
 
+  create_table "report_summaries", force: :cascade do |t|
+    t.integer  "user_id",                null: false
+    t.integer  "api_key_id",             null: false
+    t.integer  "frequency",  default: 0, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "report_summaries", ["api_key_id"], name: "index_report_summaries_on_api_key_id", using: :btree
+  add_index "report_summaries", ["user_id"], name: "index_report_summaries_on_user_id", using: :btree
+
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
@@ -66,9 +77,12 @@ ActiveRecord::Schema.define(version: 20161020130240) do
     t.integer  "role"
     t.integer  "client_id"
     t.string   "avatar"
+    t.integer  "permissions",            default: 0,  null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "report_summaries", "api_keys"
+  add_foreign_key "report_summaries", "users"
 end


### PR DESCRIPTION
Updates:

- Reports Feature. Ability to create weekly or daily reports in gui and workers/mailers for sending out PDF report. Namespaced DB tables for reports
- Basic user assigned permission - i.e. Allow All and No Emails permissions. client/company permissions not done
- dependencies/binaries for reports mailing (premailer for inlining, pdfkit for html-to-pdf generation, etc etc). development setup for testing mails locally
- stylesheets and layouts for transactional emails and pdfs
- updating endpoint for metrics collection (update required in [engage JS Client repo](https://github.com/nicksoto/engagement)
- less ugly alerts, styling bla bla
